### PR TITLE
fix IntegralProblem

### DIFF
--- a/src/Model.jl
+++ b/src/Model.jl
@@ -380,7 +380,8 @@ function holdup_time(t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=false, vis="Blu
         else
             κL = flow_restriction(L, t, T_itp, d, gas; ng=false, vis=vis)
             f_p(y, p) = d(y)^2*pressure(y, t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=false, vis=vis, control="Pressure")/T_itp(y, t)
-            prob_p = IntegralProblem(f_p, 0.0, L)
+            domain = (0.0, L)
+            prob_p = IntegralProblem(f_p, domain)
             integral = solve(prob_p, QuadGKJL(), reltol=1e-3, abstol=1e-3)[1]
             tM = 64*κL/(Fpin_itp(t)^2-pout_itp(t)^2)*integral
         end
@@ -391,7 +392,8 @@ function holdup_time(t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=false, vis="Blu
             tM = 128/3*L^2/d(L)^2*η*(pin^3-pout_itp(t)^3)/(pin^2-pout_itp(t)^2)^2
         else
             f_F(y, p) = d(y)^2*pressure(y, t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=false, vis=vis, control="Flow")/T_itp(y, t)
-            prob_F = IntegralProblem(f_F, 0.0, L)
+            domain = (0.0, L)
+            prob_F = IntegralProblem(f_F, domain)
             integral = solve(prob_F, QuadGKJL(), reltol=1e-3, abstol=1e-3)[1]
             tM = π/4 * Tn/pn * integral/Fpin_itp(t)
         end
@@ -410,7 +412,8 @@ function holdup_time(t, T_itp, Fpin_itp, pout_itp, L, d::Number, gas; ng=false, 
         else
             κL = flow_restriction(L, t, T_itp, d, gas; ng=false, vis=vis)
             f_p(y, p) = d^2*pressure(y, t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=false, vis=vis, control="Pressure")/T_itp(y, t)
-            prob_p = IntegralProblem(f_p, 0.0, L)
+            domain = (0.0, L)
+            prob_p = IntegralProblem(f_p, domain)
             integral = solve(prob_p, QuadGKJL(), reltol=1e-3, abstol=1e-3)[1]
             tM = 64*κL/(Fpin_itp(t)^2-pout_itp(t)^2)*integral
         end
@@ -421,7 +424,8 @@ function holdup_time(t, T_itp, Fpin_itp, pout_itp, L, d::Number, gas; ng=false, 
             tM = 128/3*L^2/d^2*η*(pin^3-pout_itp(t)^3)/(pin^2-pout_itp(t)^2)^2
         else
             f_F(y, p) = d^2*pressure(y, t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=false, vis=vis, control="Flow")/T_itp(y, t)
-            prob_F = IntegralProblem(f_F, 0.0, L)
+            domain = (0.0, L)
+            prob_F = IntegralProblem(f_F, domain)
             integral = solve(prob_F, QuadGKJL(), reltol=1e-3, abstol=1e-3)[1]
             tM = π/4 * Tn/pn * integral/Fpin_itp(t)
         end


### PR DESCRIPTION
change from `IntegralProblem{iip}(f::AbstractIntegralFunction, lb::Union{Number, AbstractVector{<:Number}}, ub::Union{Number, AbstractVector{<:Number}}, p = NullParameters(); kwargs...) where iip` (which is deprecated) to use `IntegralProblem{iip}(f, (lb, ub), p; kwargs...)` instead.