### PR TITLE
Fix simulate with explicit parameters

### DIFF
--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -814,6 +814,15 @@ function peaklist(sol, par; thread=false)
     return pl
 end
 
+function peaklist(sol, L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, opt; thread=false)
+    if thread == true
+        pl = peaklist_thread(sol, L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, opt)
+    else
+        pl = peaklist_unthread(sol, L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, opt)
+    end
+    return pl
+end
+
 function peaklist_thread(sol, par)
 	n = length(par.sub)
     T = typeof(sol[1].u[end][1])
@@ -929,6 +938,117 @@ function peaklist_unthread(sol, par)
         #end
     end  
     df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, Annotations = Annotations, ), [:tR])
+    for i=1:n-1
+        Res[i] = (df.tR[i+1] - df.tR[i])/(2*(df.τR[i+1] + df.τR[i]))
+        Δs[i] = (df.tR[i+1] - df.tR[i])/(df.τR[i+1] - df.τR[i]) * log(df.τR[i+1]/df.τR[i])
+    end
+    df[!, :Res] = Res
+    df[!, :Δs] = Δs 
+    
+    return select(df, [:No, :Name, :CAS, :tR, :τR, :TR, :σR, :uR, :kR, :Res, :Δs, :Annotations])
+end
+
+
+function peaklist_thread(sol, L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, opt)
+	n = length(Name)
+    T = typeof(sol[1].u[end][1])
+    # sol is solution from ODE system
+    No = Array{Union{Missing, Int64}}(undef, n)
+    tR = Array{T}(undef, n)
+    TR = Array{T}(undef, n)
+    σR = Array{T}(undef, n)
+    uR = Array{T}(undef, n)
+    τR = Array{T}(undef, n)
+    kR = Array{T}(undef, n)
+    if T == Measurements.Measurement{Float64}
+        Res = fill(NaN ± 0.0, n)
+        Δs = fill(NaN ± 0.0, n)
+    else
+        Res = fill(NaN, n)
+        Δs = fill(NaN, n)
+    end
+    Threads.@threads for i=1:n
+        if sol[i].t[end]==L
+            tR[i] = sol[i].u[end][1]
+            TR[i] = T_itp(L, tR[i]) - 273.15 
+            uR[i] = 1/residency(L, tR[i], T_itp, Fpin_itp, pout_itp, L, d, df, gas, Tchar[i], θchar[i], ΔCp[i], φ₀[i]; ng=opt.ng, vis=opt.vis, control=opt.control, k_th=opt.k_th)
+            τR[i] = sqrt(sol[i].u[end][2])
+            σR[i] = τR[i]*uR[i]
+            kR[i] = retention_factor(L, tR[i], T_itp, d, df, Tchar[i], θchar[i], ΔCp[i], φ₀[i]; k_th=opt.k_th)
+        else
+            tR[i] = NaN
+            TR[i] = NaN
+            uR[i] = NaN
+            τR[i] = NaN
+            σR[i] = NaN
+            kR[i] = NaN
+        end
+        No[i] = try
+            parse(Int,split(ann, ", ")[end])
+        catch
+            try 
+                parse(Int,split(ann, ", No: ")[end])
+            catch
+                missing
+            end
+        end
+    end  
+    df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, Annotations = ann, ), [:tR])
+    Threads.@threads for i=1:n-1
+        Res[i] = (df.tR[i+1] - df.tR[i])/(2*(df.τR[i+1] + df.τR[i]))
+        Δs[i] = (df.tR[i+1] - df.tR[i])/(df.τR[i+1] - df.τR[i]) * log(df.τR[i+1]/df.τR[i])
+    end
+    df[!, :Res] = Res
+    df[!, :Δs] = Δs 
+    
+    return select(df, [:No, :Name, :CAS, :tR, :τR, :TR, :σR, :uR, :kR, :Res, :Δs, :Annotations])
+end
+
+function peaklist_unthread(sol, L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, opt)
+	n = length(Name)
+    T = typeof(sol[1].u[end][1])
+    # sol is solution from ODE system
+    No = Array{Union{Missing, Int64}}(undef, n)
+    tR = Array{T}(undef, n)
+    TR = Array{T}(undef, n)
+    σR = Array{T}(undef, n)
+    uR = Array{T}(undef, n)
+    τR = Array{T}(undef, n)
+    kR = Array{T}(undef, n)
+    if T == Measurements.Measurement{Float64}
+        Res = fill(NaN ± 0.0, n)
+        Δs = fill(NaN ± 0.0, n)
+    else
+        Res = fill(NaN, n)
+        Δs = fill(NaN, n)
+    end
+    for i=1:n
+        if sol[i].t[end]==L
+            tR[i] = sol[i].u[end][1]
+            TR[i] = T_itp(L, tR[i]) - 273.15 
+            uR[i] = 1/residency(L, tR[i], T_itp, Fpin_itp, pout_itp, L, d, df, gas, Tchar[i], θchar[i], ΔCp[i], φ₀[i]; ng=opt.ng, vis=opt.vis, control=opt.control, k_th=opt.k_th)
+            τR[i] = sqrt(sol[i].u[end][2])
+            σR[i] = τR[i]*uR[i]
+            kR[i] = retention_factor(L, tR[i], T_itp, d, df, Tchar[i], θchar[i], ΔCp[i], φ₀[i]; k_th=opt.k_th)
+        else
+            tR[i] = NaN
+            TR[i] = NaN
+            uR[i] = NaN
+            τR[i] = NaN
+            σR[i] = NaN
+            kR[i] = NaN
+        end
+        No[i] = try
+            parse(Int,split(ann, ", ")[end])
+        catch
+            try 
+                parse(Int,split(ann, ", No: ")[end])
+            catch
+                missing
+            end
+        end
+    end  
+    df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, Annotations = ann, ), [:tR])
     for i=1:n-1
         Res[i] = (df.tR[i+1] - df.tR[i])/(2*(df.τR[i+1] + df.τR[i]))
         Δs[i] = (df.tR[i+1] - df.tR[i])/(df.τR[i+1] - df.τR[i]) * log(df.τR[i+1]/df.τR[i])

--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -1149,6 +1149,59 @@ function peaklist(sol, peak, par)
     return select(df, [:No, :Name, :CAS, :tR, :τR, :TR, :σR, :uR, :kR, :Res, :Δs, :Annotations])
 end
 
+function peaklist(sol, peak, L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, opt)
+	n = length(Name)
+    T = typeof(sol[1].u[end])
+    No = Array{Union{Missing, Int64}}(undef, n)
+    tR = Array{T}(undef, n)
+    TR = Array{T}(undef, n)
+    σR = Array{T}(undef, n)
+    uR = Array{T}(undef, n)
+    τR = Array{T}(undef, n)
+    kR = Array{T}(undef, n)
+    if T == Measurements.Measurement{Float64}
+        Res = fill(NaN ± 0.0, n)
+        Δs = fill(NaN ± 0.0, n)
+    else
+        Res = fill(NaN, n)
+        Δs = fill(NaN, n)
+    end
+    #Threads.@threads for i=1:n
+    for i=1:n
+        if sol[i].t[end]==L
+            tR[i] = sol[i].u[end]
+            TR[i] = T_itp(L, tR[i]) - 273.15 
+            uR[i] = 1/residency(L, tR[i], T_itp, Fpin_itp, pout_itp, L, d, df, gas, Tchar[i], θchar[i], ΔCp[i], φ₀[i]; ng=opt.ng, vis=opt.vis, control=opt.control, k_th=opt.k_th)
+            τR[i] = sqrt(peak[i].u[end])
+            σR[i] = τR[i]*uR[i]
+            kR[i] = retention_factor(L, tR[i], T_itp, d, df, Tchar[i], θchar[i], ΔCp[i], φ₀[i]; k_th=opt.k_th)
+        else
+            tR[i] = NaN
+            TR[i] = NaN
+            uR[i] = NaN
+            τR[i] = NaN
+            σR[i] = NaN
+            kR[i] = NaN
+        end
+        No[i] = try
+            parse(Int,split(ann, ", ")[end])
+        catch
+            missing
+        end
+    end  
+    df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, Annotations = ann, ), [:tR])
+    #Threads.@threads for i=1:n-1
+    for i=1:n-1
+        Res[i] = (df.tR[i+1] - df.tR[i])/(2*(df.τR[i+1] + df.τR[i]))
+        Δs[i] = (df.tR[i+1] - df.tR[i])/(df.τR[i+1] - df.τR[i]) * log(df.τR[i+1]/df.τR[i])
+    end
+    df[!, :Res] = Res 
+    df[!, :Δs] = Δs   
+    
+    return select(df, [:No, :Name, :CAS, :tR, :τR, :TR, :σR, :uR, :kR, :Res, :Δs, :Annotations])
+end
+
+
 """
     sol_extraction(sol, par)
 

--- a/src/Solving.jl
+++ b/src/Solving.jl
@@ -5,7 +5,7 @@
 Simulate the GC system defined by the structure `par`.
 
 Alternative call:
-`simulate(L, d, df, gas, T_itp, Fpin_itp, pout_itp, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, opt; kwargs...)`
+`simulate(L, d, df, gas, T_itp, Fpin_itp, pout_itp,Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, opt; kwargs...)`
 
 Note: Based on the option for `odesys` the result is different. For `odesys =
 true` the result is a dataframe (the peaklist) and the solution of the ODEs
@@ -25,10 +25,13 @@ function simulate(par; kwargs...)
 	end
 end
 
-function simulate(L, d, df, gas, T_itp, Fpin_itp, pout_itp, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, opt; kwargs...)
+function simulate(L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, opt; kwargs...)
     if opt.odesys==true
         sol = solve_system_multithreads(L, d, df, gas, T_itp, Fpin_itp, pout_itp, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, opt; kwargs...)
-    	pl = GasChromatographySimulator.peaklist(sol, par)
+    	# TODO: either create par from the input variables 
+        # or create new peaklist function
+        # perhaps add some parameters like 'Name' of the solutes
+        pl = GasChromatographySimulator.peaklist(sol, L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, opt)
         return pl, sol
 	else
 		sol, peak = solve_separate_multithreads(L, d, df, gas, T_itp, Fpin_itp, pout_itp, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, opt; kwargs...)

--- a/src/Solving.jl
+++ b/src/Solving.jl
@@ -35,7 +35,7 @@ function simulate(L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tcha
         return pl, sol
 	else
 		sol, peak = solve_separate_multithreads(L, d, df, gas, T_itp, Fpin_itp, pout_itp, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, opt; kwargs...)
-    	pl = GasChromatographySimulator.peaklist(sol, peak, par)
+    	pl = GasChromatographySimulator.peaklist(sol, peak, L, d, df, gas, T_itp, Fpin_itp, pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, opt)
         return pl, sol, peak
 	end
 end
@@ -110,7 +110,7 @@ function solve_separate_multithreads(par; kwargs...)
 end
 
 function solve_separate_multithreads(L, d, df, gas, T_itp, Fpin_itp, pout_itp, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, opt; kwargs...)
-    n = length(Tchar_)
+    n = length(Tchar)
     sol = Array{Any}(undef, n)
     peak = Array{Any}(undef, n)
     Threads.@threads for i=1:n

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -248,6 +248,13 @@ end
                                                     opt_ng)
     @test results_p[1].tR[1] == results_o_ng[1].tR[1]
 
+    # odesys = false
+    results_odesys_false = GasChromatographySimulator.simulate(col.L, col.d, col.df, col.gas, 
+                                                    prog_o_ng.T_itp,prog_o_ng.Fpin_itp, prog_o_ng.pout_itp, 
+                                                    Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, 
+                                                    opt[2])
+    @test isapprox(results_odesys_false[1].tR[1], results_p[1].tR[1], atol=1e-2)
+
     # vis = "HP"
     #opt_vis = GasChromatographySimulator.Options(vis="HP")
     #prog_vis = GasChromatographySimulator.Program(time_steps, temp_steps, pin_steps, pout_steps, [zeros(length(time_steps)) x₀_steps L₀_steps α_steps], opt_vis.Tcontrol, col.L)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,6 +232,22 @@ end
     @test isapprox(results_o_ng[1].tR[1], 87.41, atol=1e-2)
     @test isapprox(results_o_ng[1].τR[2], 0.590, atol=1e-3)
 
+    Name = [sub[i].name for i in 1:length(sub)]
+    CAS = [sub[i].CAS for i in 1:length(sub)]
+    ann = [sub[i].ann for i in 1:length(sub)]
+    Tchar = [sub[i].Tchar for i in 1:length(sub)]
+    θchar = [sub[i].θchar for i in 1:length(sub)]
+    ΔCp = [sub[i].ΔCp for i in 1:length(sub)]
+    φ₀ = [sub[i].φ₀ for i in 1:length(sub)]
+    Cag = [sub[i].Cag for i in 1:length(sub)]
+    t₀ = [sub[i].t₀ for i in 1:length(sub)]
+    τ₀ = [sub[i].τ₀ for i in 1:length(sub)]
+    results_p = GasChromatographySimulator.simulate(col.L, col.d, col.df, col.gas, 
+                                                    prog_o_ng.T_itp,prog_o_ng.Fpin_itp, prog_o_ng.pout_itp, 
+                                                    Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ₀, 
+                                                    opt_ng)
+    @test results_p[1].tR[1] == results_o_ng[1].tR[1]
+
     # vis = "HP"
     #opt_vis = GasChromatographySimulator.Options(vis="HP")
     #prog_vis = GasChromatographySimulator.Program(time_steps, temp_steps, pin_steps, pout_steps, [zeros(length(time_steps)) x₀_steps L₀_steps α_steps], opt_vis.Tcontrol, col.L)


### PR DESCRIPTION
- peaklist function with explicit parameters instead of 'par' for option 'odesys=false' and 'odesys=true'
- simulate function with explicit parameters instead of 'par' for option 'odesys=false' and 'odesys=true'
- tests for simulate function with explicit parameters instead of 'par' for option 'odesys=false' and 'odesys=true'
